### PR TITLE
FIx typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn add vue-money-format
     <money-format :value="cost" 
       :locale='en' 
       :currency-code='USD' 
-      :subunit-value=true 
+      :subunits-value=true 
       :hide-subunits=true>
     </money-format>
   </div>


### PR DESCRIPTION
Thanks for a great package. I was stumped when installing as the example has a typo :smile: 

Fix incorrect property name `subunit-value` (should be `subunits-value`) in README example